### PR TITLE
add build version

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -1,0 +1,9 @@
+BUILD_VERSION ?= dev
+
+.PHONY: build
+build:
+	go build -ldflags "-X 'github.com/dlph/opensnitch/build.version=$(BUILD_VERSION)'" -o opensnitchd
+
+.PHONY: clean
+clean:
+	rm opensnitchd

--- a/src/build/version.go
+++ b/src/build/version.go
@@ -1,0 +1,11 @@
+package build
+
+// version - set by build
+var version string
+
+func Version() string {
+	if version == "" {
+		version = "test"
+	}
+	return version
+}

--- a/src/cmd/requirements.go
+++ b/src/cmd/requirements.go
@@ -1,6 +1,8 @@
 package cmd
 
 import (
+	"github.com/dlph/opensnitch/build"
+
 	"github.com/evilsocket/opensnitch/daemon/core"
 	"github.com/spf13/cobra"
 )
@@ -12,5 +14,5 @@ var requirementsCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		core.CheckSysRequirements()
 	},
-	Version: "0.0.1-beta",
+	Version: build.Version(),
 }

--- a/src/cmd/root.go
+++ b/src/cmd/root.go
@@ -8,7 +8,8 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/evilsocket/opensnitch/service"
+	"github.com/dlph/opensnitch/build"
+	"github.com/dlph/opensnitch/service"
 
 	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
@@ -17,9 +18,9 @@ import (
 var rootCmd = &cobra.Command{
 	Use:     "",
 	Short:   "run daemon",
-	Long:    ``,
+	Long:    `run daemon`,
 	RunE:    runRootE,
-	Version: "0.0.1-beta",
+	Version: build.Version(),
 }
 
 func runRootE(cmd *cobra.Command, args []string) error {

--- a/src/go.mod
+++ b/src/go.mod
@@ -1,4 +1,4 @@
-module github.com/evilsocket/opensnitch
+module github.com/dlph/opensnitch
 
 go 1.21.1
 
@@ -7,15 +7,19 @@ replace github.com/evilsocket/opensnitch/daemon/ui/protocol => ../daemon/ui/prot
 require (
 	github.com/evilsocket/opensnitch/daemon v0.0.0-20240211104149-2ec37ed5939c
 	github.com/evilsocket/opensnitch/daemon/ui/protocol v0.0.0-00010101000000-000000000000
+	github.com/fsnotify/fsnotify v1.7.0
+	github.com/iovisor/gobpf v0.2.0
+	github.com/matryer/is v1.4.1
 	github.com/spf13/afero v1.11.0
 	github.com/spf13/cobra v1.8.0
 	github.com/spf13/viper v1.18.2
+	go.starlark.net v0.0.0-20240411212711-9b43f0afd521
 	go.uber.org/zap v1.27.0
+	golang.org/x/sync v0.7.0
 )
 
 require (
 	github.com/BurntSushi/toml v0.4.1 // indirect
-	github.com/fsnotify/fsnotify v1.7.0 // indirect
 	github.com/golang/protobuf v1.5.4 // indirect
 	github.com/google/go-cmp v0.6.0 // indirect
 	github.com/google/gopacket v1.1.19 // indirect
@@ -23,7 +27,6 @@ require (
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/hashicorp/hcl v1.0.0 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
-	github.com/iovisor/gobpf v0.2.0 // indirect
 	github.com/josharian/native v0.0.0-20200817173448-b6b71def0850 // indirect
 	github.com/magiconair/properties v1.8.7 // indirect
 	github.com/mdlayher/netlink v1.4.2 // indirect
@@ -43,7 +46,6 @@ require (
 	golang.org/x/exp v0.0.0-20230905200255-921286631fa9 // indirect
 	golang.org/x/mod v0.12.0 // indirect
 	golang.org/x/net v0.21.0 // indirect
-	golang.org/x/sync v0.7.0 // indirect
 	golang.org/x/sys v0.17.0 // indirect
 	golang.org/x/text v0.14.0 // indirect
 	golang.org/x/tools v0.13.0 // indirect

--- a/src/go.sum
+++ b/src/go.sum
@@ -59,6 +59,8 @@ github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
 github.com/kr/text v0.2.0/go.mod h1:eLer722TekiGuMkidMxC/pM04lWEeraHUUmBw8l2grE=
 github.com/magiconair/properties v1.8.7 h1:IeQXZAiQcpL9mgcAe1Nu6cX9LLw6ExEHKjN0VQdvPDY=
 github.com/magiconair/properties v1.8.7/go.mod h1:Dhd985XPs7jluiymwWYZ0G4Z61jb3vdS329zhj2hYo0=
+github.com/matryer/is v1.4.1 h1:55ehd8zaGABKLXQUe2awZ99BD/PTc2ls+KV/dXphgEQ=
+github.com/matryer/is v1.4.1/go.mod h1:8I/i5uYgLzgsgEloJE1U6xx5HkBQpAZvepWuujKwMRU=
 github.com/mdlayher/ethtool v0.0.0-20210210192532-2b88debcdd43/go.mod h1:+t7E0lkKfbBsebllff1xdTmyJt8lH37niI6kwFk9OTo=
 github.com/mdlayher/ethtool v0.0.0-20211028163843-288d040e9d60 h1:tHdB+hQRHU10CfcK0furo6rSNgZ38JT8uPh70c/pFD8=
 github.com/mdlayher/ethtool v0.0.0-20211028163843-288d040e9d60/go.mod h1:aYbhishWc4Ai3I2U4Gaa2n3kHWSwzme6EsG/46HRQbE=
@@ -123,6 +125,8 @@ github.com/vishvananda/netns v0.0.0-20200728191858-db3c7e526aae h1:4hwBBUfQCFe3C
 github.com/vishvananda/netns v0.0.0-20200728191858-db3c7e526aae/go.mod h1:DD4vA1DwXk04H54A1oHXtwZmA0grkVMdPxx/VGLCah0=
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.4.0/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1Zlc8k=
+go.starlark.net v0.0.0-20240411212711-9b43f0afd521 h1:1Ufp2S2fPpj0RHIQ4rbzpCdPLCPkzdK7BaVFH3nkYBQ=
+go.starlark.net v0.0.0-20240411212711-9b43f0afd521/go.mod h1:YKMCv9b1WrfWmeqdV5MAuEHWsu5iC+fe6kYl2sQjdI8=
 go.uber.org/goleak v1.3.0 h1:2K3zAYmnTNqV73imy9J1T3WC+gmCePx2hEGkimedGto=
 go.uber.org/goleak v1.3.0/go.mod h1:CoHD4mav9JJNrW/WLlf7HGZPjdw8EucARQHekz1X6bE=
 go.uber.org/multierr v1.10.0 h1:S0h4aNzvfcFsC3dRF1jLoaov7oRaKqRGC/pUEJ2yvPQ=

--- a/src/main.go
+++ b/src/main.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/evilsocket/opensnitch/cmd"
+	"github.com/dlph/opensnitch/cmd"
 )
 
 func main() {


### PR DESCRIPTION
Set build version variable in binary with `go build`.  This will allow CI/CD pipelines to set build version from build number.

If `build.version` is not set (`""`), the version will be "test" - simple indicator that the build was done manually (not part of Makefile or CI/CD).

If `build.version` is "dev" - used Makefile to generate build, but not a CI/CD build or meant for release.

`BUILD_VERSION=x.x.x make build` can be used to build a release version.